### PR TITLE
Fix to where code is actually eliminated from build as desired.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,28 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-const ENVIRONMENTS = [
-  {
-    name: "app",
-    path: "./app.js",
-  },
-  {
-    name: "test",
-    path: "./test.js",
-  },
-];
+function importBuildTarget() {
+  // DefinePlugin in webpack.config.js will substitute
+  // process.env.REACT_APP_BUILD_TARGET with it's value at build time.
+  // https://webpack.js.org/plugins/define-plugin/
 
-// Determine which entry point to import
-const { path } = ENVIRONMENTS.find(
-  ({ name }) => process.env.REACT_APP_BUILD_TARGET === name
-);
+  // TerserPlugin in webpack.config.js will eliminate dead code
+  // ...if we make it easy enough (no maps or switches, etc).
+  // https://webpack.js.org/plugins/terser-webpack-plugin/
+
+  if (process.env.REACT_APP_BUILD_TARGET === "app") {
+    return import("./app.js");
+  } else if (process.env.REACT_APP_BUILD_TARGET === "test") {
+    return import("./test.js");
+  } else {
+    return Promise.reject(
+      new Error("No such build target: " + process.env.REACT_APP_BUILD_TARGET)
+    );
+  }
+}
 
 // Import the entry point and render it's default export
-import(`${path}`).then(({ default: Environment }) =>
+importBuildTarget().then(({ default: Environment }) =>
   ReactDOM.render(
     <React.StrictMode>
       <Environment />


### PR DESCRIPTION
As Will mentions in the following comment, "`each file is still included in the bundle and can be accessed if you find the chunk filename, i.e.the ‘test’ module is accessible in the ‘app’ deployment and vice versa.`"

https://blog.logrocket.com/multiple-entry-points-in-create-react-app-without-ejecting/#comment-4116

The workaround in this pull request gets the desired outcome.